### PR TITLE
Fix mobile nav menu being pushed off-screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -680,6 +680,7 @@
           position: fixed;
           top: 64px;
           left: -100%;
+          transform: none;
           width: 80vw;
           max-width: 300px;
           height: calc(100vh - 64px);


### PR DESCRIPTION
## Summary
- `.nav-menu` uses `transform: translateX(-50%)` on desktop to center itself, but the mobile breakpoint (`@media max-width: 768px`) switches it to a fixed-position slide-in drawer positioned via `left`/`.active` instead, without resetting `transform`.
- The leftover `-50%` transform (of the drawer's own 300px width) shifted the open menu 150px further left than intended, leaving nav links mostly off-screen and unusable on mobile.
- Added `transform: none` inside the mobile media query so the drawer's `left: 0` open position isn't offset. Verified via Playwright that the open menu now sits at `x: 0` with all links visible, and that desktop nav centering is unaffected.

## Test plan
- [x] Rendered the site with Playwright at 390px width, opened the hamburger menu, confirmed all nav links (Home/Features/Discord/Updates/FAQ/Contact) are fully visible and on-screen.
- [x] Confirmed desktop (1440px) nav remains centered as before.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P4vgkjcFgRFUxcigQx3t3m)_